### PR TITLE
Remove ubuntu image from explorer container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,6 @@ version: '2'
 services:
 
   explorer:
-    image: ubuntu:16.04
     build:
       context: ../
       dockerfile: docker/explorer/Dockerfile


### PR DESCRIPTION
In case the ubuntu image is known to docker it will skip building the explorer.