### PR TITLE
docker-compose.yml: Add gui directory to volumes of explorer docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       dockerfile: docker/explorer/Dockerfile
     volumes:
       - ../../explorer-data/target:/root/target
+      - ../gui:/build_docker/gui
     ports:
       - "5000:5000"
     networks:


### PR DESCRIPTION
This adds the gui directory the volumes of the explorer image so it doesn't need to be rebuilt during front-end development and other updates.